### PR TITLE
Support for redis 4

### DIFF
--- a/lib/redmon/redis.rb
+++ b/lib/redmon/redis.rb
@@ -15,7 +15,7 @@ module Redmon
     ]
 
     def redis
-      @redis ||= ::Redis.connect(:url => Redmon.config.redis_url)
+      @redis ||= ::Redis.new(:url => Redmon.config.redis_url)
     end
 
     def ns


### PR DESCRIPTION
Since redis 4 the previously deprecated #connect method has been removed. Redmon should use #new instead.